### PR TITLE
Add ability to pass options

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var stripJsonComments = require('strip-json-comments');
 
-module.exports = function () {
+module.exports = function (options) {
+	console.log ("development strip json");
+	console.log ("options: ", options);
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			cb(null, file);
@@ -15,7 +17,7 @@ module.exports = function () {
 		}
 
 		try {
-			file.contents = new Buffer(stripJsonComments(file.contents.toString()));
+			file.contents = new Buffer(stripJsonComments(file.contents.toString(), options));
 			this.push(file);
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-strip-json-comments', err, {fileName: file.path}));

--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ var through = require('through2');
 var stripJsonComments = require('strip-json-comments');
 
 module.exports = function (options) {
-	console.log ("development strip json");
-	console.log ("options: ", options);
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			cb(null, file);

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,26 @@ gulp.task('default', function () {
 });
 ```
 
+### Options
+
+You can set the configuration to strip comments and their equivalent whitespace instead of replacing them with whitespace (which is the default).
+
+[Strip-json-comments whitespace option](https://github.com/sindresorhus/strip-json-comments#options)  
+
+```js
+var gulp = require('gulp');
+var stripJsonComments = require('gulp-strip-json-comments');
+
+const strippingOptions = {whitespace: false};
+
+gulp.task('default', function () {
+	return gulp.src('src/config.json')
+		.pipe(stripJsonComments(strippingOptions))
+		.pipe(gulp.dest('dist'));
+});
+```
+
+
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -15,3 +15,18 @@ it('should strip JSON comments', function (cb) {
 		contents: new Buffer('//comment\n{"a":"b"}')
 	}));
 });
+
+it('should strip JSON comments and whitespace with options', function (cb) {
+	var options = {whitespace: false};
+	var stream = stripJsonComments(options);
+
+	stream.on('data', function (file) {
+		assert.equal(file.contents.toString(), '\n{"a":"b"}');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		contents: new Buffer('//comment   \n{"a":"b"}')
+	}));
+});
+


### PR DESCRIPTION
passes options to the strip-json-comments plugin, which recognizes the whitespace parameter.
also add test for removing whitespace.